### PR TITLE
chore: remove `redcarpet` dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@
 source 'https://rubygems.org'
 
 gem 'jekyll', '~> 4.x'
-gem 'redcarpet', '~> 3.x'
 
 group :jekyll_plugins do
   gem 'jekyll-paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,6 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    redcarpet (3.6.1)
     rexml (3.4.4)
     rouge (4.6.1)
     ruby-rc4 (0.1.5)
@@ -152,7 +151,6 @@ DEPENDENCIES
   jekyll-feed
   jekyll-paginate
   jekyll-seo-tag
-  redcarpet (~> 3.x)
 
 BUNDLED WITH
    2.7.1


### PR DESCRIPTION
It's not used for anything :shrug: